### PR TITLE
ADAPT-1354

### DIFF
--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -6,7 +6,8 @@
 
 define([
     'coreViews/componentView',
-    'coreJS/adapt'
+    'coreJS/adapt',
+    'underscore'
 ], function(ComponentView, Adapt) {
 
     var Flipcard = ComponentView.extend({
@@ -30,6 +31,10 @@ define([
         postRender: function() {
             if (!Modernizr.csstransforms3d) {
                 this.$('.flipcard-item-back').hide();
+            }
+
+            if (_.isEmpty(this.model.get('_flipDirection'))) {
+                this.$('.flipcard-item').addClass('horizontal');
             }
 
             this.$('.flipcard-widget').imageready(_.bind(function() {

--- a/templates/flipcard.hbs
+++ b/templates/flipcard.hbs
@@ -4,11 +4,11 @@
     <div class="flipcard-widget component-widget clearfix">
         {{#each _items}}
         <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}">
-            <div class="flipcard-item-face flipcard-item-front">
-                <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}" tabindex="0">
+            <div class="flipcard-item-face flipcard-item-front" tabindex="0">
+                <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}">
             </div>
 
-            <div class="flipcard-item-face flipcard-item-back">
+            <div class="flipcard-item-face flipcard-item-back" tabindex="0">
                 {{#if backTitle}}
                 <div class="flipcard-item-back-title h4">
                 {{{backTitle}}}


### PR DESCRIPTION
Flipcard component was jumping to another component on the page after card had been flipped both directions (on tablet devices). This was fixed by adding a tabindex attribute to front and rear facing divs. 

Also added a fail safe for `_flipDirection` as courses built with flipcard component before the new _flipDirection property was added won't work. 
