### PR TITLE
Updating Min-Height Value for Half-Width Components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": "^2.0.0",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "homepage": "https://github.com/ExultCorp/adapt-contrib-flipcard",
     "issues": "https://github.com/ExultCorp/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/ExultCorp/adapt-contrib-flipcard.git",

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -60,7 +60,7 @@
 
         .component-left&,
         .component-right& {
-            min-height: auto;
+            min-height: initial;
         }
 
         &.flipcard-flip  {

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -60,7 +60,7 @@
 
         .component-left&,
         .component-right& {
-            min-height: initial;
+            min-height: 0;
         }
 
         &.flipcard-flip  {


### PR DESCRIPTION
Setting the `min-height` property value to `auto` or `initial` causes problems across browsers and/or themes. Setting a specific value fixes the issue in iOS and browser / theme combinations. 