### PR TITLE
Explicit min-height for items set for iOS

### DIFF
--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -60,7 +60,7 @@
 
         .component-left&,
         .component-right& {
-            min-height: 0;
+            min-height: 150px;
         }
 
         &.flipcard-flip  {


### PR DESCRIPTION
iOS was still giving issues with a `min-height` value of 0. This property is now explicitly set, which addresses the issue.