### PR TITLE
screenreader reads out text on back of flipcard when it is not visible

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": "^2.0.0",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "homepage": "https://github.com/ExultCorp/adapt-contrib-flipcard",
     "issues": "https://github.com/ExultCorp/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/ExultCorp/adapt-contrib-flipcard.git",

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -30,7 +30,7 @@ define([
         // this is use to set ready status for current component on postRender.
         postRender: function() {
             _.each(this.$('.flipcard-item'), function(el) {
-                this.toggleFlipcardAccessibility($(el));
+                this.toggleCardSideVisibility($(el));
             }.bind(this));
 
             if (!Modernizr.csstransforms3d) {
@@ -132,6 +132,16 @@ define([
         },
 
         toggleFlipcardAccessibility: function($selectedElement) {
+            if (this.model.get('flipType') === 'allFlip') {
+                this.toggleCardSideVisibility($selectedElement);
+            } else {
+                _.each(this.$('.flipcard-item'), function(el) {
+                    this.toggleCardSideVisibility($(el));
+                }.bind(this));
+            }
+        },
+
+        toggleCardSideVisibility: function($selectedElement) {
             var hasBeenFlipped = ($selectedElement.hasClass('flipcard-flip')) ? true : false;
             var $front = $selectedElement.find('.flipcard-item-front');
             var $back = $selectedElement.find('.flipcard-item-back');

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -81,7 +81,7 @@ define([
 
         // Click or Touch event handler for flip card.
         onClickFlipItem: function(event) {
-            if(event && event.target.tagName.toLowerCase() === 'a') {
+            if (event && event.target.tagName.toLowerCase() === 'a') {
                 return;
             } else {
                 event && event.preventDefault();
@@ -89,6 +89,10 @@ define([
 
             var $selectedElement = $(event.currentTarget);
             var flipType = this.model.get('_flipType');
+
+            var hasBeenFlipped = ($selectedElement.hasClass('flipcard-flip')) ? true : false;
+            this.toggleFlipcardAccessibility(hasBeenFlipped, $selectedElement);
+
             if (flipType === 'allFlip') {
                 this.performAllFlip($selectedElement);
             } else if (flipType === 'singleFlip') {
@@ -103,6 +107,7 @@ define([
                 var $frontflipcard = $selectedElement.find('.flipcard-item-front');
                 var $backflipcard = $selectedElement.find('.flipcard-item-back');
                 var flipTime = this.model.get('_flipTime') || 'fast';
+
                 if ($frontflipcard.is(':visible')) {
                     $frontflipcard.fadeOut(flipTime, function() {
                         $backflipcard.fadeIn(flipTime);
@@ -118,6 +123,27 @@ define([
 
             var flipcardElementIndex = this.$('.flipcard-item').index($selectedElement);
             this.setVisited(flipcardElementIndex);
+        },
+
+        toggleFlipcardAccessibility: function(hasBeenFlipped, $selectedElement) {
+            var $frontTitle = $selectedElement.find('.flipcard-item-front-title')
+            var $frontBody = $selectedElement.find('.flipcard-item-front-body')
+            var $backTitle = $selectedElement.find('.flipcard-item-back-title');
+            var $backBody = $selectedElement.find('.flipcard-item-back-body')
+
+            if (hasBeenFlipped) {
+                $backTitle.attr('aria-hidden', 'true').addClass('a11y-ignore');
+                $backBody.attr('aria-hidden', 'true').addClass('a11y-ignore');
+
+                $frontTitle.attr('aria-hidden', 'false').removeClass('a11y-ignore');
+                $frontBody.attr('aria-hidden', 'false').removeClass('a11y-ignore');
+            } else {
+                $backTitle.attr('aria-hidden', 'false').removeClass('a11y-ignore');
+                $backBody.attr('aria-hidden', 'false').removeClass('a11y-ignore');
+
+                $frontTitle.attr('aria-hidden', 'true').addClass('a11y-ignore');
+                $frontBody.attr('aria-hidden', 'true').addClass('a11y-ignore');
+            }
         },
 
         // This function will be responsible to perform Single flip on flipcard where

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -22,13 +22,17 @@ define([
 
             // Adding classes for ie8
             if ($('html').hasClass('ie8')) {
-              $(".flipcard-item:nth-child(even)").addClass("even");
-              $(".flipcard-item:nth-child(odd)").addClass("odd");
+                $(".flipcard-item:nth-child(even)").addClass("even");
+                $(".flipcard-item:nth-child(odd)").addClass("odd");
             }
         },
 
         // this is use to set ready status for current component on postRender.
         postRender: function() {
+            _.each(this.$('.flipcard-item'), function(el) {
+                this.toggleFlipcardAccessibility($(el));
+            }.bind(this));
+
             if (!Modernizr.csstransforms3d) {
                 this.$('.flipcard-item-back').hide();
             }
@@ -75,9 +79,9 @@ define([
         },
 
         // This function called on triggering of device resize and device change event of Adapt.
-        reRender: function() {           
+        reRender: function() {
             this.setFlipComponentHeight();
-         },
+        },
 
         // Click or Touch event handler for flip card.
         onClickFlipItem: function(event) {
@@ -90,14 +94,16 @@ define([
             var $selectedElement = $(event.currentTarget);
             var flipType = this.model.get('_flipType');
 
-            var hasBeenFlipped = ($selectedElement.hasClass('flipcard-flip')) ? true : false;
-            this.toggleFlipcardAccessibility(hasBeenFlipped, $selectedElement);
-
             if (flipType === 'allFlip') {
                 this.performAllFlip($selectedElement);
             } else if (flipType === 'singleFlip') {
                 this.performSingleFlip($selectedElement);
             }
+
+            _.defer(_.bind(function() {
+                this.toggleFlipcardAccessibility($selectedElement);
+                $selectedElement.a11y_focus();
+            }, this));
         },
 
         // This function will be responsible to perform All flip on flipcard
@@ -125,24 +131,19 @@ define([
             this.setVisited(flipcardElementIndex);
         },
 
-        toggleFlipcardAccessibility: function(hasBeenFlipped, $selectedElement) {
-            var $frontTitle = $selectedElement.find('.flipcard-item-front-title')
-            var $frontBody = $selectedElement.find('.flipcard-item-front-body')
-            var $backTitle = $selectedElement.find('.flipcard-item-back-title');
-            var $backBody = $selectedElement.find('.flipcard-item-back-body')
+        toggleFlipcardAccessibility: function($selectedElement) {
+            var hasBeenFlipped = ($selectedElement.hasClass('flipcard-flip')) ? true : false;
+            var $front = $selectedElement.find('.flipcard-item-front');
+            var $back = $selectedElement.find('.flipcard-item-back');
 
             if (hasBeenFlipped) {
-                $backTitle.attr('aria-hidden', 'true').addClass('a11y-ignore');
-                $backBody.attr('aria-hidden', 'true').addClass('a11y-ignore');
-
-                $frontTitle.attr('aria-hidden', 'false').removeClass('a11y-ignore');
-                $frontBody.attr('aria-hidden', 'false').removeClass('a11y-ignore');
+                // Hide back, enable front
+                $front.attr('aria-hidden', 'true').addClass('a11y-ignore');
+                $back.attr('aria-hidden', 'false').removeClass('a11y-ignore');
             } else {
-                $backTitle.attr('aria-hidden', 'false').removeClass('a11y-ignore');
-                $backBody.attr('aria-hidden', 'false').removeClass('a11y-ignore');
-
-                $frontTitle.attr('aria-hidden', 'true').addClass('a11y-ignore');
-                $frontBody.attr('aria-hidden', 'true').addClass('a11y-ignore');
+                // Hide front, enable back
+                $front.attr('aria-hidden', 'false').removeClass('a11y-ignore');
+                $back.attr('aria-hidden', 'true').addClass('a11y-ignore');
             }
         },
 

--- a/templates/flipcard.hbs
+++ b/templates/flipcard.hbs
@@ -3,23 +3,23 @@
     {{> component this}}
     <div class="flipcard-widget component-widget clearfix">
         {{#each _items}}
-        <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}">
+        <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}" tabindex="0">
             <div class="flipcard-item-face flipcard-item-front">
                 {{#if frontImage.alt}}
-                <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}" tabindex="0">
+                <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}">
                 {{else}}
-                <img src="{{frontImage.src}}" class="flipcard-item-frontImage a11y-ignore" aria-hidden="true" tabindex="-1">
+                <img src="{{frontImage.src}}" class="flipcard-item-frontImage a11y-ignore" aria-hidden="true" >
                 {{/if}}
             </div>
 
-            <div class="flipcard-item-face flipcard-item-back" tabindex="0">
+            <div class="flipcard-item-face flipcard-item-back">
                 {{#if backTitle}}
-                <div class="flipcard-item-back-title h4 a11y-ignore" aria-hidden="true">
+                <div class="flipcard-item-back-title h4">
                 {{{backTitle}}}
                 </div>
                 {{/if}}
                 {{#if backBody}}
-                <div class="flipcard-item-back-body a11y-ignore" aria-hidden="true">
+                <div class="flipcard-item-back-body">
                 {{{backBody}}}
                 </div>
                 {{/if}}

--- a/templates/flipcard.hbs
+++ b/templates/flipcard.hbs
@@ -14,12 +14,12 @@
 
             <div class="flipcard-item-face flipcard-item-back" tabindex="0">
                 {{#if backTitle}}
-                <div class="flipcard-item-back-title h4">
+                <div class="flipcard-item-back-title h4 a11y-ignore" aria-hidden="true">
                 {{{backTitle}}}
                 </div>
                 {{/if}}
                 {{#if backBody}}
-                <div class="flipcard-item-back-body">
+                <div class="flipcard-item-back-body a11y-ignore" aria-hidden="true">
                 {{{backBody}}}
                 </div>
                 {{/if}}


### PR DESCRIPTION
flipcard back now has a11y-ignore and aria-hidden on them as default. When it is clicked, a new toggleFlipcardAccessibility function handles removing the default property/class from back and adding them to front.