### PR TITLE
ADAPT-4343 Fix transitions on Edge and Android

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "homepage": "https://github.com/ExultCorp/adapt-contrib-flipcard",
     "issues": "https://github.com/ExultCorp/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/ExultCorp/adapt-contrib-flipcard.git",

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -20,35 +20,38 @@ define([
             this.listenTo(Adapt, 'device:resize', this.reRender, this);
             this.checkIfResetOnRevisit();
 
-            // Adding classes for ie8
-            if ($('html').hasClass('ie8')) {
-                $(".flipcard-item:nth-child(even)").addClass("even");
-                $(".flipcard-item:nth-child(odd)").addClass("odd");
-            }
+            _.each(this.model.get('_items'), function(item) {
+                if (!item._flipDirection) {
+                    item._flipDirection = 'horizontal';
+                }
+            });
         },
 
         // this is use to set ready status for current component on postRender.
         postRender: function() {
-            _.each(this.$('.flipcard-item'), function(el) {
+            // Adding classes for ie8
+            if ($('html').hasClass('ie8')) {
+                this.$(".flipcard-item:nth-child(even)").addClass("even");
+                this.$(".flipcard-item:nth-child(odd)").addClass("odd");
+            }
+
+            var items = this.model.get('_items');
+            var $items = this.$('.flipcard-item');
+
+            _.each($items, function(el, i) {
                 this.toggleCardSideVisibility($(el));
+
             }.bind(this));
 
             if (!Modernizr.testProp('transformStyle', 'preserve-3d')) {
                 this.$('.flipcard-item-back').hide();
             }
 
-            if (_.isEmpty(this.model.get('_flipDirection'))) {
-                this.$('.flipcard-item').addClass('horizontal');
-            }
+            // Width css class for single or multiple images in flipcard.
+            var className = (items.length > 1) ? 'flipcard-multiple' : 'flipcard-single';
+            $items.addClass(className);
 
             this.$('.flipcard-widget').imageready(_.bind(function() {
-                // Width css class for single or multiple images in flipcard.
-                if (this.$('.flipcard-inner').find('img').length > 1) {
-                    this.$('.flipcard-item').addClass('flipcard-multiple');
-                } else {
-                    this.$('.flipcard-item').addClass('flipcard-single');
-                }
-
                 this.setFlipComponentHeight();
                 this.setReadyStatus();
             }, this));
@@ -148,7 +151,7 @@ define([
         },
 
         toggleCardSideVisibility: function($selectedElement) {
-            var hasBeenFlipped = ($selectedElement.hasClass('flipcard-flip')) ? true : false;
+            var hasBeenFlipped = $selectedElement.hasClass('flipcard-flip');
             var $front = $selectedElement.find('.flipcard-item-front');
             var $back = $selectedElement.find('.flipcard-item-back');
 

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -76,7 +76,12 @@
         }
 
         .vendor-prefix (perspective, 600px);
-        .vendor-prefix (transform-style, preserve-3d);
+
+        // ADAPT-4343 Fixes a display bug in Edge
+        // Introduces other bugs in IOS so make it exclusive to Edge
+        .edge & {
+          transform-style: preserve-3d;
+        }
 
         html.size-medium &,
         html.size-small & {

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -104,7 +104,7 @@
             // still shows front and back of card
             &.flipcard-item-front,
             &.flipcard-item-back {
-              [class*="version-11"] & {
+              [class*="version-11"].ie & {
                 transition: 0;
               }
             }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -76,6 +76,7 @@
         }
 
         .vendor-prefix (perspective, 600px);
+        .vendor-prefix (transform-style, preserve-3d);
 
         html.size-medium &,
         html.size-small & {

--- a/templates/flipcard.hbs
+++ b/templates/flipcard.hbs
@@ -3,28 +3,28 @@
     {{> component this}}
     <div class="flipcard-widget component-widget clearfix">
         {{#each _items}}
-        <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}" tabindex="0">
-            <div class="flipcard-item-face flipcard-item-front">
-                {{#if frontImage.alt}}
-                <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}">
-                {{else}}
-                <img src="{{frontImage.src}}" class="flipcard-item-frontImage a11y-ignore" aria-hidden="true" >
-                {{/if}}
-            </div>
+            <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}" tabindex="0">
+                    <div class="flipcard-item-face flipcard-item-front">
+                        {{#if frontImage.alt}}
+                            <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}">
+                        {{else}}
+                            <img src="{{frontImage.src}}" class="flipcard-item-frontImage a11y-ignore" aria-hidden="true">
+                        {{/if}}
+                    </div>
 
-            <div class="flipcard-item-face flipcard-item-back">
-                {{#if backTitle}}
-                <div class="flipcard-item-back-title h4">
-                {{{backTitle}}}
+                    <div class="flipcard-item-face flipcard-item-back">
+                        {{#if backTitle}}
+                            <div class="flipcard-item-back-title h4">
+                                {{{backTitle}}}
+                            </div>
+                        {{/if}}
+                        {{#if backBody}}
+                            <div class="flipcard-item-back-body">
+                                {{{backBody}}}
+                            </div>
+                        {{/if}}
+                    </div>
                 </div>
-                {{/if}}
-                {{#if backBody}}
-                <div class="flipcard-item-back-body">
-                {{{backBody}}}
-                </div>
-                {{/if}}
-            </div>
-        </div>
         {{/each}}
     </div>
 </div>

--- a/templates/flipcard.hbs
+++ b/templates/flipcard.hbs
@@ -4,27 +4,27 @@
     <div class="flipcard-widget component-widget clearfix">
         {{#each _items}}
             <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}" tabindex="0">
-                    <div class="flipcard-item-face flipcard-item-front">
-                        {{#if frontImage.alt}}
-                            <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}">
-                        {{else}}
-                            <img src="{{frontImage.src}}" class="flipcard-item-frontImage a11y-ignore" aria-hidden="true">
-                        {{/if}}
-                    </div>
-
-                    <div class="flipcard-item-face flipcard-item-back">
-                        {{#if backTitle}}
-                            <div class="flipcard-item-back-title h4">
-                                {{{backTitle}}}
-                            </div>
-                        {{/if}}
-                        {{#if backBody}}
-                            <div class="flipcard-item-back-body">
-                                {{{backBody}}}
-                            </div>
-                        {{/if}}
-                    </div>
+                <div class="flipcard-item-face flipcard-item-front">
+                    {{#if frontImage.alt}}
+                        <img src="{{frontImage.src}}" class="flipcard-item-frontImage" aria-label="{{frontImage.alt}}">
+                    {{else}}
+                        <img src="{{frontImage.src}}" class="flipcard-item-frontImage a11y-ignore" aria-hidden="true">
+                    {{/if}}
                 </div>
+
+                <div class="flipcard-item-face flipcard-item-back">
+                    {{#if backTitle}}
+                        <div class="flipcard-item-back-title h4">
+                            {{{backTitle}}}
+                        </div>
+                    {{/if}}
+                    {{#if backBody}}
+                        <div class="flipcard-item-back-body">
+                            {{{backBody}}}
+                        </div>
+                    {{/if}}
+                </div>
+            </div>
         {{/each}}
     </div>
 </div>


### PR DESCRIPTION
- .flipcard-item needed tranform-style: preserve3d property for Edge
- vertical items were getting both vertical and horizontal classes
- moved ie8 class assignments to postRender and bound them to the component view scope
- slight refactoring to improve code