### PR TITLE
ADAPT-4745 - Windows 7 IE11 bug fix

### DIFF
--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -181,7 +181,7 @@ define([
                 if ($backflipcard.is(':visible')) {     
                     $backflipcard.fadeOut(flipTime, function() {
                         $frontflipcard.fadeIn(flipTime);
-                        $flipcardItem.addClass('flipcard-flip');
+                        $flipcardItem.removeClass('flipcard-flip');
                     });
                 } else {
                     var $visibleflipcardBack = $flipcardContainer.find('.flipcard-item-back:visible');
@@ -193,6 +193,7 @@ define([
                     }
                     $frontflipcard.fadeOut(flipTime, function() {
                         $backflipcard.fadeIn(flipTime);
+                        $flipcardItem.addClass('flipcard-flip');
                     });
                 }
             } else {

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -181,10 +181,10 @@ define([
                         $backflipcard.fadeIn(flipTime);
                     });
                 } else {
-                    var visibleflipcardBack = $flipcardContainer.find('.flipcard-item-back:visible');
-                    if (visibleflipcardBack.length > 0) {
+                    var $visibleflipcardBack = $flipcardContainer.find('.flipcard-item-back:visible');
+                    if ($visibleflipcardBack.length > 0) {
                         $flipcardItem.removeClass('flipcard-flip');
-                        visibleflipcardBack.fadeOut(flipTime, function() {
+                        $visibleflipcardBack.fadeOut(flipTime, function() {
                             $flipcardContainer.find('.flipcard-item-front:hidden').fadeIn(flipTime);
                         });
                     }

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -129,9 +129,11 @@ define([
                         $frontflipcard.fadeIn(flipTime);
                     });
                 }
-            } else {
-                $selectedElement.toggleClass('flipcard-flip');
             }
+
+            // Regardless of whether or not csstransforms3d is supported
+            // the flipcard-flip class should be added
+            $selectedElement.toggleClass('flipcard-flip');
 
             var flipcardElementIndex = this.$('.flipcard-item').index($selectedElement);
             this.setVisited(flipcardElementIndex);
@@ -166,32 +168,35 @@ define([
         // This function will be responsible to perform Single flip on flipcard where
         // only one card can flip and stay in the flipped state.
         performSingleFlip: function($selectedElement) {
-            var flipcardContainer = $selectedElement.closest('.flipcard-widget');
+            var $flipcardContainer = $selectedElement.closest('.flipcard-widget');
             if (!Modernizr.csstransforms3d) {
-                var frontflipcard = $selectedElement.find('.flipcard-item-front');
-                var backflipcard = $selectedElement.find('.flipcard-item-back');
+                var $flipcardItem = $selectedElement.closest('.flipcard-item');
+                var $frontflipcard = $selectedElement.find('.flipcard-item-front');
+                var $backflipcard = $selectedElement.find('.flipcard-item-back');
                 var flipTime = this.model.get('_flipTime') || 'fast';
 
-                if (backflipcard.is(':visible')) {
-                    backflipcard.fadeOut(flipTime, function() {
-                        frontflipcard.fadeIn(flipTime);
+                if ($frontflipcard.is(':visible')) {
+                    $flipcardItem.addClass('flipcard-flip');
+                    $frontflipcard.fadeOut(flipTime, function() {
+                        $backflipcard.fadeIn(flipTime);
                     });
                 } else {
-                    var visibleflipcardBack = flipcardContainer.find('.flipcard-item-back:visible');
+                    var visibleflipcardBack = $flipcardContainer.find('.flipcard-item-back:visible');
                     if (visibleflipcardBack.length > 0) {
+                        $flipcardItem.removeClass('flipcard-flip');
                         visibleflipcardBack.fadeOut(flipTime, function() {
-                            flipcardContainer.find('.flipcard-item-front:hidden').fadeIn(flipTime);
+                            $flipcardContainer.find('.flipcard-item-front:hidden').fadeIn(flipTime);
                         });
                     }
-                    frontflipcard.fadeOut(flipTime, function() {
-                        backflipcard.fadeIn(flipTime);
+                    $backflipcard.fadeOut(flipTime, function() {
+                        $frontflipcard.fadeIn(flipTime);
                     });
                 }
             } else {
                 if ($selectedElement.hasClass('flipcard-flip')) {
                     $selectedElement.removeClass('flipcard-flip');
                 } else {
-                    flipcardContainer.find('.flipcard-item').removeClass('flipcard-flip');
+                    $flipcardContainer.find('.flipcard-item').removeClass('flipcard-flip');
                     $selectedElement.addClass('flipcard-flip');
                 }
             }

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -178,17 +178,17 @@ define([
                 var $backflipcard = $selectedElement.find('.flipcard-item-back');
                 var flipTime = this.model.get('_flipTime') || 'fast';
 
-                if ($backflipcard.is(':visible')) {
-                    $flipcardItem.addClass('flipcard-flip');
+                if ($backflipcard.is(':visible')) {     
                     $backflipcard.fadeOut(flipTime, function() {
                         $frontflipcard.fadeIn(flipTime);
+                        $flipcardItem.addClass('flipcard-flip');
                     });
                 } else {
                     var $visibleflipcardBack = $flipcardContainer.find('.flipcard-item-back:visible');
                     if ($visibleflipcardBack.length > 0) {
-                        $flipcardItem.removeClass('flipcard-flip');
                         $visibleflipcardBack.fadeOut(flipTime, function() {
                             $flipcardContainer.find('.flipcard-item-front:hidden').fadeIn(flipTime);
+                            $flipcardItem.removeClass('flipcard-flip');
                         });
                     }
                     $frontflipcard.fadeOut(flipTime, function() {

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -57,7 +57,6 @@
         margin: 0;
         padding: 0;
         margin-bottom: .5%;
-        overflow: hidden;
 
         .component-left&,
         .component-right& {

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -57,6 +57,7 @@
         margin: 0;
         padding: 0;
         margin-bottom: .5%;
+        overflow: hidden;
 
         .component-left&,
         .component-right& {


### PR DESCRIPTION
A customer's course has an issue on Windows 7 - IE11.

We were able to replicate the issue using their course and the problem appeared to be that the moderniser library found IE11's support for `csstransform3d` false.

This fix makes sure that the `flipcard-flip` class that is required for displaying the back of the flipcard correctly is also applied even if the moderniser `!Modernizr.csstransforms3d` check evaluates to true.

Fix for ADAPT-4409 has also been added within this PR as it's such a small fix.