### PR TITLE
ADAPT-5453 - fix for IE11 blurry text when flipped

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "homepage": "https://github.com/learningpool/adapt-contrib-flipcard",
     "issues": "https://github.com/learningpool/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/learningpool/adapt-contrib-flipcard.git",

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -140,6 +140,7 @@
       &.flipcard-item-front,
       &.flipcard-item-back {
         [class*='version-11'].ie & {
+          transform: none;
           transition: 0;
         }
       }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -140,8 +140,15 @@
       &.flipcard-item-front,
       &.flipcard-item-back {
         [class*='version-11'].ie & {
-          transform: none;
           transition: 0;
+        }
+      }
+      
+      &.flipcard-item-back[aria-hidden="false"] {
+        [class*='version-11'].ie & {
+          // stop text blur as flip is not currently
+          // supported in IE11
+          transform: none;
         }
       }
 


### PR DESCRIPTION
This minor fix removes blurry text on IE11 which is not using the transition anymore.