### PR TITLE
Adapt 5242 - Flipcard - item images not showing in edge

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "homepage": "https://github.com/learningpool/adapt-contrib-flipcard",
     "issues": "https://github.com/learningpool/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/learningpool/adapt-contrib-flipcard.git",

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -107,12 +107,6 @@
       background-color: transparent;
     }
 
-    // ADAPT-4343 Fixes a display bug in Edge
-    // Introduces other bugs in IOS so make it exclusive to Edge
-    .edge & {
-      transform-style: preserve-3d;
-    }
-
     html.size-medium &,
     html.size-small & {
       margin-bottom: 5px;


### PR DESCRIPTION
Removed styling that was causing the flipcards to not display correctly. This does not have any knock on effects to the animation as shown in this video: https://www.loom.com/share/585f802959fa47cc83b4288c845f4f1d