### PR TITLE
ADAPT-6051 Link in FlipCard is active even on the backside

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "homepage": "https://github.com/learningpool/adapt-contrib-flipcard",
     "issues": "https://github.com/learningpool/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/learningpool/adapt-contrib-flipcard.git",

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -141,8 +141,8 @@ define([
             var $textElements = $back.children();
 
             $textElements.a11y_cntrl_enabled(hasBeenFlipped);
-            $front.attr('aria-hidden', hasBeenFlipped).toggleClass('a11y-ignore', hasBeenFlipped);
-            $back.attr('aria-hidden', !hasBeenFlipped).toggleClass('a11y-ignore', !hasBeenFlipped);
+            $front.attr('aria-hidden', hasBeenFlipped).toggleClass('a11y-ignore display-none', hasBeenFlipped);
+            $back.attr('aria-hidden', !hasBeenFlipped).toggleClass('a11y-ignore display-none', !hasBeenFlipped);
         },
 
         // This function will be responsible to perform Single flip on flipcard where


### PR DESCRIPTION
Description of issue: We found that links on Flipcards are available even on the front side.
I.E. - you can access the link by accident when clicking on the flipcard if you click on the exact spot where the link is.

Added display none class for disabling elements on the hidden side of the flipcard.