### PR TITLE
Fixed issue with flipcard not appearing after a number of clicks on IE11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "3.0.5",
+    "version": "3.0.4",
     "homepage": "https://github.com/learningpool/adapt-contrib-flipcard",
     "issues": "https://github.com/learningpool/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/learningpool/adapt-contrib-flipcard.git",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "3.0.3",
+    "version": "3.0.5",
     "homepage": "https://github.com/learningpool/adapt-contrib-flipcard",
     "issues": "https://github.com/learningpool/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/learningpool/adapt-contrib-flipcard.git",

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -143,6 +143,12 @@ define([
             $textElements.a11y_cntrl_enabled(hasBeenFlipped);
             $front.attr('aria-hidden', hasBeenFlipped).toggleClass('a11y-ignore', hasBeenFlipped);
             $back.attr('aria-hidden', !hasBeenFlipped).toggleClass('a11y-ignore', !hasBeenFlipped);
+
+            if (hasBeenFlipped) {
+                $back.show();
+            } else {
+                $back.hide();
+            }
         },
 
         // This function will be responsible to perform Single flip on flipcard where

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -143,12 +143,6 @@ define([
             $textElements.a11y_cntrl_enabled(hasBeenFlipped);
             $front.attr('aria-hidden', hasBeenFlipped).toggleClass('a11y-ignore', hasBeenFlipped);
             $back.attr('aria-hidden', !hasBeenFlipped).toggleClass('a11y-ignore', !hasBeenFlipped);
-
-            if (hasBeenFlipped) {
-                $back.show();
-            } else {
-                $back.hide();
-            }
         },
 
         // This function will be responsible to perform Single flip on flipcard where

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -150,6 +150,6 @@
 
   // Make links on Flipcards not available on the front side
   .flipcard-item-face.flipcard-item-back[aria-hidden="true"] {
-    pointer-events: none; 
+    pointer-events: none;
   }
 }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -141,7 +141,7 @@
 
     // Show the back item
     .flipcard-item-back {
-      display: inline-block;
+      pointer-events: all;
       opacity: 1;
       overflow-x: hidden;
       overflow-y: auto;
@@ -150,7 +150,8 @@
 
   .flipcard-single {
     .flipcard-item-back[aria-hidden="true"] {
-      display: none;
+      pointer-events: none;
+      cursor: default;
     }
   }
 }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -150,6 +150,6 @@
 
   // Make links on Flipcards not available on the front side
   .flipcard-item-face.flipcard-item-back[aria-hidden="true"] {
-    pointer-events: none;
+    pointer-events: none; 
   }
 }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -141,6 +141,7 @@
 
     // Show the back item
     .flipcard-item-back {
+      pointer-events: all;
       opacity: 1;
       overflow-x: hidden;
       overflow-y: auto;
@@ -148,10 +149,7 @@
   }
 
   // Make links on Flipcards not available on the front side
-  .flipcard-item-face.flipcard-item-back {
+  .flipcard-item-face.flipcard-item-back[aria-hidden="true"] {
     pointer-events: none;
-    .flipcard-flip & {
-      pointer-events: all;
-    }
   }
 }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -141,9 +141,16 @@
 
     // Show the back item
     .flipcard-item-back {
+      display: inline-block;
       opacity: 1;
       overflow-x: hidden;
       overflow-y: auto;
+    }
+  }
+
+  .flipcard-single {
+    .flipcard-item-back[aria-hidden="true"] {
+      display: none;
     }
   }
 }

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -141,7 +141,6 @@
 
     // Show the back item
     .flipcard-item-back {
-      pointer-events: none;
       opacity: 1;
       overflow-x: hidden;
       overflow-y: auto;

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -141,17 +141,18 @@
 
     // Show the back item
     .flipcard-item-back {
-      pointer-events: all;
+      pointer-events: none;
       opacity: 1;
       overflow-x: hidden;
       overflow-y: auto;
     }
   }
 
-  .flipcard-single {
-    .flipcard-item-back[aria-hidden="true"] {
-      pointer-events: none;
-      cursor: default;
+  // Make links on Flipcards not available on the front side
+  .flipcard-item-face.flipcard-item-back {
+    pointer-events: none;
+    .flipcard-flip & {
+      pointer-events: all;
     }
   }
 }


### PR DESCRIPTION
Description of issue: Preview in IE11
Click on the Flipcard, make sure to click on it a few times
Expected Results:
Flipcard will remain in view, no matter how many times you click.