### PR TITLE
ADAPT-5416 fix blurry text

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "adapt-contrib-flipcard",
     "framework": ">=3.0.0",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "homepage": "https://github.com/learningpool/adapt-contrib-flipcard",
     "issues": "https://github.com/learningpool/adapt-contrib-flipcard/issues",
     "repository": "git://github.com/learningpool/adapt-contrib-flipcard.git",

--- a/js/adapt-contrib-flipcard.js
+++ b/js/adapt-contrib-flipcard.js
@@ -35,7 +35,7 @@ define([
             $items.addClass(className);
 
             this.$('.flipcard-widget').imageready(_.bind(function() {
-                this.setFlipComponentHeight();
+                this.setItemDimensions();
                 this.setReadyStatus();
             }, this));
 
@@ -56,17 +56,28 @@ define([
         },
 
         // This function sets the height of the flipcard component to the first image in the component.
-        setFlipComponentHeight: function() {
-            var imageHeight = this.$('.flipcard-item-frontImage').eq(0).height();
+        setItemDimensions: function() {
+            var $firstItemImage = this.$('.flipcard-item-frontImage').eq(0);
+
+            var $items = this.$('.flipcard-item');
+            var flexBasis = $items.length >  1 ? '49%' : '100%';
+
+            // Reset width so that dimensions can be recalculated
+            $items.css({ flexBasis: flexBasis });
+
+            var imageHeight = Math.round($firstItemImage.height());
+            var itemWidth = Math.floor($items.eq(0).outerWidth());
 
             if (imageHeight) {
-                this.$('.flipcard-item').height(imageHeight);
+                $items.height(imageHeight);
             }
+
+            $items.css({ flexBasis: itemWidth });
         },
 
         // This function called on triggering of device resize and device change event of Adapt.
         reRender: function() {
-            this.setFlipComponentHeight();
+            this.setItemDimensions();
         },
 
         // Click or Touch event handler for flip card.

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -28,6 +28,9 @@
 // Scope the styles to flipcard-component's
 .flipcard-component {
   .flipcard-widget {
+    display: flex;
+    justify-content: space-between;
+
     .vendor-prefix(perspective, 600px);
   }
 
@@ -40,7 +43,7 @@
     background-color: transparent !important;
     border: 0;
     color: @item-text-color;
-    float: left;
+    //float: left;
     margin: 0 0 5px;
     overflow: hidden;
     padding: 0;
@@ -63,15 +66,7 @@
 
       // Spacing between side by side items
       &.flipcard-multiple {
-        width: 49%;
-
-        &:nth-child(odd) {
-          margin-right: 1%;
-        }
-
-        &:nth-child(even) {
-          margin-left: 1%;
-        }
+        flex: 0 0 49%;
       }
     }
 

--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -43,7 +43,6 @@
     background-color: transparent !important;
     border: 0;
     color: @item-text-color;
-    //float: left;
     margin: 0 0 5px;
     overflow: hidden;
     padding: 0;

--- a/templates/flipcard.hbs
+++ b/templates/flipcard.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Himanshu Rajotia <himanshu.rajotia@exultcorp.com>}}
 <div class="flipcard-inner component-inner" role="region" aria-label="{{_globals._components._flipcard.ariaRegion}}">
     {{> component this}}
-    <div class="flipcard-widget component-widget clearfix">
+    <div class="flipcard-widget component-widget">
         {{#each _items}}
             <div class="flipcard-item component-item item-{{@index}} {{_flipDirection}}" tabindex="0">
                 <div class="flipcard-item-face flipcard-item-front">


### PR DESCRIPTION
Blurry text on transforms caused by percentage width not being an
integer. Solution: use JS to round widths and flexbox to ensure elements
are pushed left and right without floating.

Also ensure that responsive behaviour is retained.