### PR TITLE
Fix: Added tabindex to flipcard__item-face for a11y

### DIFF
--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -4,7 +4,7 @@ import { templates, classes, compile } from 'core/js/reactHelpers';
 export default function flipcard(props) {
   return (
     <div
-      className='component__inner flipcard__inner' 
+      className='component__inner flipcard__inner'
       role='region'
     >
 
@@ -13,8 +13,8 @@ export default function flipcard(props) {
       <div className='component__widget flipcard__widget clearfix'>
 
         {props._items.map(({ backBody, backTitle, frontImage, _flipDirection }, index) =>
-          
-          <div 
+
+          <div
             className={classes([
               `component__item flipcard__item item-${index} ${_flipDirection}`,
             ])}
@@ -23,6 +23,7 @@ export default function flipcard(props) {
             <div
               className='flipcard__item-face flipcard__item-front'
               role='button'
+              tabindex='0'
             >
               <img
                 className='flipcard__item-frontImage'
@@ -32,8 +33,9 @@ export default function flipcard(props) {
             </div>
 
             <div
-              className='flipcard__item-face flipcard__item-back' 
+              className='flipcard__item-face flipcard__item-back'
               role='button'
+              tabindex='0'
             >
               { backTitle &&
                 <div
@@ -51,7 +53,7 @@ export default function flipcard(props) {
                 </div>
               }
             </div>
-            
+
           </div>
         )}
       </div>


### PR DESCRIPTION
<!-->Please title your PR according to eslint commit conventions</!-->
<!-->See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details</!-->
<!-->e.g. "Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)"</!-->
<!-->or "Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)"</!-->

<!-->Link the PR to the original issue</!-->
Fixes [ADAPT-10445](https://learningpool.atlassian.net/browse/ADAPT-10445)

<!-->Delete Fix, New, Breaking sections as appropriate</!-->
### Fix
* tabindex 0 added to appropriate divs to allow keyboard navigation

<!-->List appropriate steps for testing if needed</!-->
### Testing
1. Create a basic course with Flipcard component
2. Add items to Flipcard with a lot of text (so scroll will be needed to see it all)
3. Preview course and confirm that tab/arrow keys do not ever give focus to Flipcard component
4. Install plugin https://github.com/LearningPool/adapt-contrib-flipcard/archive/refs/heads/ADAPT-10445.zip
5. Rebuild and preview course
6. Flipcard should now be focusable via keyboard navigation
7. Enter/space should trigger the flip action
8. down/up arrows should allow scroll of text content