### PR TITLE
ADAPT-10819 Fix: Missing tabIndex on flipcard items

### DIFF
--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -19,11 +19,12 @@ export default function flipcard(props) {
               `component__item flipcard__item item-${index} ${_flipDirection}`,
             ])}
             key={index}
+            tabIndex='0'
           >
             <div
               className='flipcard__item-face flipcard__item-front'
               role='button'
-              tabindex='0'
+              tabIndex='0'
             >
               <img
                 className='flipcard__item-frontImage'
@@ -35,7 +36,7 @@ export default function flipcard(props) {
             <div
               className='flipcard__item-face flipcard__item-back'
               role='button'
-              tabindex='0'
+              tabIndex='0'
             >
               { backTitle &&
                 <div

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -23,6 +23,7 @@ export default function flipcard(props) {
             <div
               className='flipcard__item-face flipcard__item-front'
               role='button'
+              tabIndex='0'
             >
               <img
                 className='flipcard__item-frontImage'

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -19,12 +19,10 @@ export default function flipcard(props) {
               `component__item flipcard__item item-${index} ${_flipDirection}`,
             ])}
             key={index}
-            tabIndex='0'
           >
             <div
               className='flipcard__item-face flipcard__item-front'
               role='button'
-              tabIndex='0'
             >
               <img
                 className='flipcard__item-frontImage'


### PR DESCRIPTION
<!-->Link the PR to the original issue</!-->
fixes [ADAPT-10817](https://learningpool.atlassian.net/browse/ADAPT-10817)

### Fix
Ensured tabIndex on item to allow it to receive the class .focus-visible. Also updated 2 instances to uppercase 'Index' as error was flagged in console.
