### PR TITLE
Fix: Flipcard reveal title does not have heading role or ARIA level attributes [Adapt-11524]

### DIFF
--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -16,7 +16,7 @@ export default function flipcard(props) {
 
           <div
             className={classes([
-              `component__item flipcard__item item-${index} ${_flipDirection}`,
+              `component__item flipcard__item item-${index} ${_flipDirection}`
             ])}
             key={index}
           >
@@ -34,15 +34,18 @@ export default function flipcard(props) {
 
             <div
               className='flipcard__item-face flipcard__item-back'
-              role='button'
               tabIndex='-1'
+              style={{ position: 'relative' }}
             >
+              <button
+                className='flipcard__item-back-button'
+              />
               { backTitle &&
                 <div
                   className='flipcard__item-back-title'
                   role='heading'
                   aria-level={4}
-                  dangerouslySetInnerHTML={{ __html: compile(backTitle)}}
+                  dangerouslySetInnerHTML={{ __html: compile(backTitle) }}
                 >
                 </div>
               }
@@ -50,12 +53,11 @@ export default function flipcard(props) {
               { backBody &&
                 <div
                   className='flipcard__item-back-body'
-                  dangerouslySetInnerHTML={{ __html: compile(backBody)}}
+                  dangerouslySetInnerHTML={{ __html: compile(backBody) }}
                 >
                 </div>
               }
             </div>
-
           </div>
         )}
       </div>

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -35,7 +35,6 @@ export default function flipcard(props) {
             <div
               className='flipcard__item-face flipcard__item-back'
               tabIndex='-1'
-              style={{ position: 'relative' }}
             >
               <button
                 className='flipcard__item-back-button'

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -41,7 +41,7 @@ export default function flipcard(props) {
                 <div
                   className='flipcard__item-back-title'
                   role='heading'
-                  aria-level={'4'}
+                  aria-level={4}
                   dangerouslySetInnerHTML={{ __html: compile(backTitle)}}
                 >
                 </div>

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -40,6 +40,8 @@ export default function flipcard(props) {
               { backTitle &&
                 <div
                   className='flipcard__item-back-title'
+                  role='heading'
+                  aria-level={'4'}
                   dangerouslySetInnerHTML={{ __html: compile(backTitle)}}
                 >
                 </div>


### PR DESCRIPTION
<!-->Link the PR to the original issue</!-->
https://learningpool.atlassian.net/browse/ADAPT-11524

### Fix
* Added role and aria level to flipcard item title
