### PR TITLE
Fix: Separate the button from title to ensure accessibility [ADAPT-11524]

### DIFF
--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -16,7 +16,7 @@ export default function flipcard(props) {
 
           <div
             className={classes([
-              `component__item flipcard__item item-${index} ${_flipDirection}`,
+              `component__item flipcard__item item-${index} ${_flipDirection}`
             ])}
             key={index}
           >
@@ -34,15 +34,18 @@ export default function flipcard(props) {
 
             <div
               className='flipcard__item-face flipcard__item-back'
-              role='button'
               tabIndex='-1'
+              style={{ position: 'relative' }}
             >
+              <button
+                className='flipcard__item-back-button'
+              />
               { backTitle &&
                 <div
                   className='flipcard__item-back-title'
                   role='heading'
                   aria-level={4}
-                  dangerouslySetInnerHTML={{ __html: compile(backTitle)}}
+                  dangerouslySetInnerHTML={{ __html: compile(backTitle) }}
                 >
                 </div>
               }
@@ -50,12 +53,11 @@ export default function flipcard(props) {
               { backBody &&
                 <div
                   className='flipcard__item-back-body'
-                  dangerouslySetInnerHTML={{ __html: compile(backBody)}}
+                  dangerouslySetInnerHTML={{ __html: compile(backBody) }}
                 >
                 </div>
               }
             </div>
-
           </div>
         )}
       </div>

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -35,7 +35,6 @@ export default function flipcard(props) {
             <div
               className='flipcard__item-face flipcard__item-back'
               tabIndex='-1'
-              style={{ position: 'relative' }}
             >
               <button
                 className='flipcard__item-back-button'


### PR DESCRIPTION
<!-->Link the PR to the original issue</!-->
fixes ADAPT-11524

<!-->Delete Fix, New, Breaking sections as appropriate</!-->
### Fix
* Separating the button from the title and body so voiceover recognises the button and title individually; needed to ensure the title heading level is ready out by voiceover.
