### PR TITLE
Update: Added a backAriaLabel property for a11y (ADAPT-12310)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-flipcard",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "framework": ">=5.19.1",
   "homepage": "https://github.com/HT2-Labs/adapt-contrib-flipcard",
   "repository": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-flipcard",
-  "version": "5.3.0",
+  "version": "5.2.1",
   "framework": ">=5.19.1",
   "homepage": "https://github.com/HT2-Labs/adapt-contrib-flipcard",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-flipcard",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "framework": ">=5.19.1",
   "homepage": "https://github.com/HT2-Labs/adapt-contrib-flipcard",
   "repository": {

--- a/properties.schema
+++ b/properties.schema
@@ -110,6 +110,16 @@
             "validators": [],
             "help": "Enter body text for back side of flipcard element",
             "translatable": true
+          },
+          "backAriaLabel": {
+            "type": "string",
+            "required": false,
+            "inputType": "Text",
+            "title": "Back Button Aria Label",
+            "default": "",
+            "validators": [],
+            "help": "Enter an aria label for the flipcard back button. If empty, this will default to the Item Title",
+            "translatable": true
           }
         }
       }

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -12,7 +12,7 @@ export default function flipcard(props) {
 
       <div className='component__widget flipcard__widget clearfix'>
 
-        {props._items.map(({ backBody, backTitle, frontImage, _flipDirection }, index) =>
+        {props._items.map(({ backBody, backTitle, backAriaLabel, frontImage, _flipDirection }, index) =>
           <div
             className={classes([
               `component__item flipcard__item item-${index} ${_flipDirection}`
@@ -27,7 +27,8 @@ export default function flipcard(props) {
               <img
                 className='flipcard__item-frontImage'
                 src={frontImage?.src}
-                aria-label={frontImage?.alt}>
+                aria-label={frontImage?.alt}
+              >
               </img>
             </div>
 
@@ -38,6 +39,7 @@ export default function flipcard(props) {
               <div
                 className='flipcard__item-back-button'
                 role='button'
+                aria-label={backAriaLabel || backTitle}
               >
                 { backTitle &&
                   <div

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -35,26 +35,27 @@ export default function flipcard(props) {
               className='flipcard__item-face flipcard__item-back'
               tabIndex='-1'
             >
-              <button
+              <div
                 className='flipcard__item-back-button'
+                role='button'
               />
-              { backTitle &&
-                <div
-                  className='flipcard__item-back-title'
-                  role='heading'
-                  aria-level={4}
-                  dangerouslySetInnerHTML={{ __html: compile(backTitle) }}
-                >
-                </div>
-              }
+                { backTitle &&
+                  <div
+                    className='flipcard__item-back-title'
+                    role='heading'
+                    dangerouslySetInnerHTML={{ __html: compile(backTitle) }}
+                  >
+                  </div>
+                }
 
-              { backBody &&
-                <div
-                  className='flipcard__item-back-body'
-                  dangerouslySetInnerHTML={{ __html: compile(backBody) }}
-                >
-                </div>
-              }
+                { backBody &&
+                  <div
+                    className='flipcard__item-back-body'
+                    dangerouslySetInnerHTML={{ __html: compile(backBody) }}
+                  >
+                  </div>
+                }
+              </div>
             </div>
           </div>
         )}

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -38,7 +38,7 @@ export default function flipcard(props) {
               <div
                 className='flipcard__item-back-button'
                 role='button'
-              />
+              >
                 { backTitle &&
                   <div
                     className='flipcard__item-back-title'


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes: ADAPT-12310

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Switching the orphaned back-button to be a nesting element with the button role to help a11y

### Update
* Added a backAriaLabel property for a11y