### PR TITLE
Fix: Adding overflow auto to flipcard item face to allow scrollable content when larger than box size (ADAPT-12396)

### DIFF
--- a/less/flipcard.less
+++ b/less/flipcard.less
@@ -43,6 +43,7 @@
       height: 100%;
       transform-style: preserve-3d;
       transition: transform 1s;
+      overflow: auto;
       width: 100%;
 
       &.flipcard__item-front .flipcard__item-frontImage {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
ADAPT-12396

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Adding overflow auto to flipcard item face to allow scrollable content when larger than box size